### PR TITLE
Iss4rebrand

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ to <jellycuts@gmail.com>.
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](openjelly.github.io/Open-Jellycore/documentation/open_jellycore/).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://openjelly.github.io/Open-Jellycore/documentation/open_jellycore/).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/OpenJelly/Open-Jellycore/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
@@ -61,7 +61,7 @@ We will then take care of the issue as soon as possible.
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](openjelly.github.io/Open-Jellycore/documentation/open_jellycore/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://openjelly.github.io/Open-Jellycore/documentation/open_jellycore/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/OpenJelly/Open-Jellycore/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
@@ -101,7 +101,7 @@ This section guides you through submitting an enhancement suggestion for Open Je
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](openjelly.github.io/Open-Jellycore/documentation/open_jellycore/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Read the [documentation](https://openjelly.github.io/Open-Jellycore/documentation/open_jellycore/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](https://github.com/OpenJelly/Open-Jellycore/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Open Jellycore Code of Conduct](https://github.com/ActuallyTaylor/Open-Jellycoreblob/master/CODE_OF_CONDUCT.md).
+[Open Jellycore Code of Conduct](https://github.com/OpenJelly/Open-Jellycore/blob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <jellycuts@gmail.com>.
 
@@ -38,11 +38,11 @@ to <jellycuts@gmail.com>.
 
 > If you want to ask a question, we assume that you have read the available [Documentation](actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/).
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/ActuallyTaylor/Open-Jellycore/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/OpenJelly/Open-Jellycore/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](https://github.com/ActuallyTaylor/Open-Jellycore/issues/new).
+- Open an [Issue](https://github.com/OpenJelly/Open-Jellycore/issues/new).
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
 
@@ -62,7 +62,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/ActuallyTaylor/Open-Jellycoreissues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/OpenJelly/Open-Jellycore/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
@@ -79,7 +79,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://github.com/ActuallyTaylor/Open-Jellycore/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://github.com/OpenJelly/Open-Jellycore/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -102,13 +102,13 @@ This section guides you through submitting an enhancement suggestion for Open Je
 
 - Make sure that you are using the latest version.
 - Read the [documentation](actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](https://github.com/ActuallyTaylor/Open-Jellycore/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Perform a [search](https://github.com/OpenJelly/Open-Jellycore/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 <!-- omit in toc -->
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/ActuallyTaylor/Open-Jellycore/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/OpenJelly/Open-Jellycore/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
@@ -124,11 +124,11 @@ The first steps in contributing to Open Jellycore is getting the repository runn
 #### Cloning the repository using the Terminal
 To correctly clone the repository it is **VERY** important that you use the `--recursive` flag when using the `git clone` command. This will ensure that all of the correct submodules are cloned.
 ```
-git clone --recursive https://github.com/ActuallyTaylor/Open-Jellycore.git
+git clone --recursive https://github.com/OpenJelly/Open-Jellycore.git
 ``` 
 
 #### Cloning using a Git Client
-A git client should be able to just take the url `https://github.com/ActuallyTaylor/Open-Jellycore.git` and properly clone all of the submodules. If you are missing submodules we recommend that you use the command line to clone instead of a client.
+A git client should be able to just take the url `https://github.com/OpenJelly/Open-Jellycore.git` and properly clone all of the submodules. If you are missing submodules we recommend that you use the command line to clone instead of a client.
 
 #### The Rest
 The rest of the process is fairly straight forward and really pretty simple. You just need to open the `Package.swift` file that is found within the folder you just cloned. This will open the swift package in Xcode and prepare all of the Swift Packages used by the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/OpenJe
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
+- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://gitlab.gnome.org/Archive/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
 - **Explain why this enhancement would be useful** to most Open Jellycore users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ to <jellycuts@gmail.com>.
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/).
+> If you want to ask a question, we assume that you have read the available [Documentation](openjelly.github.io/Open-Jellycore/documentation/open_jellycore/).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/OpenJelly/Open-Jellycore/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
@@ -61,7 +61,7 @@ We will then take care of the issue as soon as possible.
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](openjelly.github.io/Open-Jellycore/documentation/open_jellycore/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/OpenJelly/Open-Jellycore/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
@@ -101,7 +101,7 @@ This section guides you through submitting an enhancement suggestion for Open Je
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Read the [documentation](openjelly.github.io/Open-Jellycore/documentation/open_jellycore/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](https://github.com/OpenJelly/Open-Jellycore/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
@@ -134,7 +134,7 @@ A git client should be able to just take the url `https://github.com/OpenJelly/O
 The rest of the process is fairly straight forward and really pretty simple. You just need to open the `Package.swift` file that is found within the folder you just cloned. This will open the swift package in Xcode and prepare all of the Swift Packages used by the project.
 
 ### Improving The Documentation
-Whenever uou make a contribution you should make sure you also are improving the documentation. Open Jellycore is almost completely documented using [DocC](https://developer.apple.com/documentation/docc). This documentation is then generated and uploaded to the documentation site https://actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/. When you create new parts of Jellycore be sure to document as you go!
+Whenever uou make a contribution you should make sure you also are improving the documentation. Open Jellycore is almost completely documented using [DocC](https://developer.apple.com/documentation/docc). This documentation is then generated and uploaded to the documentation site https://openjelly.github.io/Open-Jellycore/documentation/open_jellycore/. When you create new parts of Jellycore be sure to document as you go!
 
 ## Styleguides
 ### Commit Messages


### PR DESCRIPTION
#16 

### replace github.com/ActuallyTaylor with github.com/OpenJelly

### replace actuallytaylor.github.io/Open-Jellycore/documentation with https://openjelly.github.io/Open-Jellycore/documentation
without https:// resulted in 404

### line 32 added missing slash to URL, 404 otherwise

### line 65 added missing slash to URL, 404 otherwise

### replace (https://github.com/GNOME/byzanz) with (https://gitlab.gnome.org/Archive/byzanz) , 404 otherwise
