### PR TITLE
Minor typo and grammatical fixes in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Open Jellycore Code of Conduct](https://github.com/ActuallyTaylor/Open-Jellycoreblob/master/CODE_OF_CONDUCT.md).
+[Open Jellycore Code of Conduct](https://github.com/OpenJelly/Open-Jellycore/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <jellycuts@gmail.com>.
 
@@ -134,11 +134,11 @@ A git client should be able to just take the url `https://github.com/ActuallyTay
 The rest of the process is fairly straight forward and really pretty simple. You just need to open the `Package.swift` file that is found within the folder you just cloned. This will open the swift package in Xcode and prepare all of the Swift Packages used by the project.
 
 ### Improving The Documentation
-Whenever uou make a contribution you should make sure you also are improving the documentation. Open Jellycore is almost completely documented using [DocC](https://developer.apple.com/documentation/docc). This documentation is then generated and uploaded to the documentation site https://actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/. When you create new parts of Jellycore be sure to document as you go!
+Whenever you make a contribution you should make sure you also are improving the documentation. Open Jellycore is almost completely documented using [DocC](https://developer.apple.com/documentation/docc). This documentation is then generated and uploaded to the documentation site https://actuallytaylor.github.io/Open-Jellycore/documentation/open_jellycore/. When you create new parts of Jellycore be sure to document as you go!
 
 ## Styleguides
 ### Commit Messages
-Commit messages do not have an particular style. Just make sure they make it clear what you changed.
+Commit messages do not have a particular style. Just make sure they make it clear what you changed.
 
 ## Join The Project Team
 Currently we are not accepting a new lead maintainers for the project. But we may be in the future!

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 An open source version of the originally closed source Jellycore. This package handles all of the transpiling of Jelly -> Shortcuts.
 
 ## Compiling in the Command Line
-To compile a Jellycut using the CLI, you will need to first install Jelly from the [homebrew](https://brew.sh) package manager. 
+To compile a Jellycut using the CLI, you will need to first install Jelly from the [Homebrew](https://brew.sh) package manager. 
 
 ```
 # Get the brew tap that hosts Jelly
@@ -36,12 +36,12 @@ You may see this package and ask, Why is this a brand new repository?
 
 The answer is quite simple, the old repository is extremely bloated and with 3 years of history I was not able to quickly ensure nothing sensitive was accidentally being leaked. Jellycore used to be closely linked to Jellycuts so a lot of the code is hard to understand and poorly documented. 
 
-The creation of a new repository turned out to be faster and much more efficient then converting the old Jellycore into a repository that was safe to Open Source. Rewriting Jellycore also provided me the ability to document every piece of code so it is easy for anyone looking at it to understand. 
+The creation of a new repository turned out to be faster and much more efficient than converting the old Jellycore into a repository that was safe to Open Source. Rewriting Jellycore also provided me the ability to document every piece of code so it is easy for anyone looking at it to understand. 
 
-Even though this is a new repository, you will see parts of code that have been present since the original versions of Jellycuts. The information at the top of files is was kept when moving files.
+Even though this is a new repository, you will see parts of code that have been present since the original versions of Jellycuts. The information at the top of files was kept when moving files.
 
 ## Features (Compared to Private Jellycore)
-Because this is a brand new version of Jellycore, it does not currently support all of the original features of the Jelly languages. However, Open Jellycore will eventually have feature parody with the Private Jellycore versions.
+Because this is a brand new version of Jellycore, it does not currently support all of the original features of the Jelly language. However, Open Jellycore will eventually have feature parity with the Private Jellycore versions.
 
 | Feature                        | Open Jellycore | Private Jellycore |
 | ------------------------------ | -------------- | ----------------- |
@@ -72,4 +72,4 @@ I have written this version of Jellycore with the intention of it being possible
 The entirety of Jellycore is documented using Doc-C. [See Online documentation](https://openjelly.github.io/Open-Jellycore/documentation/open_jellycore/).
 
 # Contributing
-If you are curious about contributing or where to start, the Features header is a great place to look at what is still left! If you are looking for smaller things to fix, there are a plethora of `// TODO:` comments throughout the library that are all small fixes or additions that would be nice to have.
+If you are curious about contributing or where to start, the Features header is a great place to look at what is still left! If you are looking for smaller things to fix, there is a plethora of `// TODO:` comments throughout the library that are all small fixes or additions that would be nice to have.


### PR DESCRIPTION
## Fixing typos and grammatical errors in README.md and CONTRIBUTING.md

### Description

This PR fixes several typos and grammatical issues in the `README.md` file:

- **Feature Parity**: Corrected "feature parody" to "feature parity" to accurately describe matching features.
- **Efficiency Comparison**: Changed "then" to "than" for proper comparative grammar.
- **Sentence Clarity**: Removed an extra "is" to improve readability.
- **Proper Noun Capitalization**: Capitalized "Homebrew" as it is a proper noun.
- **Subject-Verb Agreement**: Adjusted "there are a plethora" to "there is a plethora" for correct grammatical agreement.

As well as three in the  `CONTRIBUTING.md` file:

- **Minor typo**: Corrected "uou" to "you" under the Improving The Documentation section.
- **Sentence Clarity**: Changed“an particular style” to “a particular style” for proper grammatical usage under the Styleguides section.
- **Broken Code of Conduct link fixed**: Code of contact previously references the master branch which github does not find, this has been updated to the main branch's version of the file.

### Motivation

Sorry I'm just one of those people who intrusively notices typos at times, fixing up some minor bits will help better present things on the main page of the repo and maintain professionalism. 

### Type of Change

- [x] Documentation update

### Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and that 100% of my very minor changes are aligned with the legal notice.
- [x] I have verified that the documentation changes are accurate.
- [x] I have ensured that no other content was unintentionally modified.

---

Let me know if there's anything else you'd like to add or adjust in the PR!